### PR TITLE
Fix loc.end in multi-line jsx attribute values, basic test runner

### DIFF
--- a/test/driver.js
+++ b/test/driver.js
@@ -1,0 +1,107 @@
+var tests = [];
+
+exports.test = function(code, ast, options) {
+  tests.push({code: code, ast: ast, options: options});
+};
+exports.testFail = function(code, message, options) {
+  tests.push({code: code, error: message, options: options});
+};
+exports.testAssert = function(code, assert, options) {
+  tests.push({code: code, assert: assert, options: options});
+};
+
+exports.runTests = function(config, callback) {
+  var parse = config.parse;
+
+  for (var i = 0; i < tests.length; ++i) {
+    var test = tests[i];
+    if (config.filter && !config.filter(test)) continue;
+    try {
+      var testOpts = test.options || {locations: true};
+      var expected = {};
+      if (expected.onComment = testOpts.onComment) {
+        testOpts.onComment = []
+      }
+      if (expected.onToken = testOpts.onToken) {
+        testOpts.onToken = [];
+      }
+      testOpts.plugins = { jsx: true };
+      var ast = parse(test.code, testOpts);
+      if (test.error) {
+        if (config.loose) {
+          callback("ok", test.code);
+        } else {
+          callback("fail", test.code, "Expected error message: " + test.error + "\nBut parsing succeeded.");
+        }
+      }
+      else if (test.assert) {
+        var error = test.assert(ast);
+        if (error) callback("fail", test.code,
+                               "\n  Assertion failed:\n " + error);
+        else callback("ok", test.code);
+      } else {
+        var mis = misMatch(test.ast, ast);
+        for (var name in expected) {
+          if (mis) break;
+          if (expected[name]) {
+            mis = misMatch(expected[name], testOpts[name]);
+            testOpts[name] = expected[name];
+          }
+        }
+        if (mis) callback("fail", test.code, mis);
+        else callback("ok", test.code);
+      }
+    } catch(e) {
+      if (!(e instanceof SyntaxError)) {
+        throw e;
+      }
+      if (test.error) {
+        if (e.message == test.error) callback("ok", test.code);
+        else callback("fail", test.code,
+                      "Expected error message: " + test.error + "\nGot error message: " + e.message);
+      } else {
+        callback("error", test.code, e.stack || e.toString());
+      }
+    }
+  }
+};
+
+function ppJSON(v) { return v instanceof RegExp ? v.toString() : JSON.stringify(v, null, 2); }
+function addPath(str, pt) {
+  if (str.charAt(str.length-1) == ")")
+    return str.slice(0, str.length-1) + "/" + pt + ")";
+  return str + " (" + pt + ")";
+}
+
+var misMatch = exports.misMatch = function(exp, act) {
+  if (!exp || !act || (typeof exp != "object") || (typeof act != "object")) {
+    if (exp !== act) return ppJSON(exp) + " !== " + ppJSON(act);
+  } else if (exp instanceof RegExp || act instanceof RegExp) {
+    var left = ppJSON(exp), right = ppJSON(act);
+    if (left !== right) return left + " !== " + right;
+  } else if (exp.splice) {
+    if (!act.slice) return ppJSON(exp) + " != " + ppJSON(act);
+    if (act.length != exp.length) return "array length mismatch " + exp.length + " != " + act.length;
+    for (var i = 0; i < act.length; ++i) {
+      var mis = misMatch(exp[i], act[i]);
+      if (mis) return addPath(mis, i);
+    }
+  } else {
+    for (var prop in exp) {
+      var mis = misMatch(exp[prop], act[prop]);
+      if (mis) return addPath(mis, prop);
+    }
+  }
+};
+
+function mangle(ast) {
+  if (typeof ast != "object" || !ast) return;
+  if (ast.slice) {
+    for (var i = 0; i < ast.length; ++i) mangle(ast[i]);
+  } else {
+    var loc = ast.start && ast.end && {start: ast.start, end: ast.end};
+    if (loc) { delete ast.start; delete ast.end; }
+    for (var name in ast) if (ast.hasOwnProperty(name)) mangle(ast[name]);
+    if (loc) ast.loc = loc;
+  }
+}

--- a/test/run.js
+++ b/test/run.js
@@ -1,0 +1,71 @@
+var driver = require("./driver.js");
+require("..");
+require("./tests-jsx.js");
+
+function group(name) {
+  if (typeof console === "object" && console.group) {
+    console.group(name);
+  }
+}
+
+function groupEnd() {
+  if (typeof console === "object" && console.groupEnd) {
+    console.groupEnd(name);
+  }
+}
+
+function log(title, message) {
+  if (typeof console === "object") console.log(title, message);
+}
+
+var stats, modes = {
+  Normal: {
+    config: {
+      parse: require("acorn").parse
+    }
+  }
+};
+
+function report(state, code, message) {
+  if (state != "ok") {++stats.failed; log(code, message);}
+  ++stats.testsRun;
+}
+
+group("Errors");
+
+for (var name in modes) {
+  group(name);
+  var mode = modes[name];
+  stats = mode.stats = {testsRun: 0, failed: 0};
+  var t0 = +new Date;
+  driver.runTests(mode.config, report);
+  mode.stats.duration = +new Date - t0;
+  groupEnd();
+}
+
+groupEnd();
+
+function outputStats(name, stats) {
+  log(name + ":", stats.testsRun + " tests run in " + stats.duration + "ms; " +
+    (stats.failed ? stats.failed + " failures." : "all passed."));
+}
+
+var total = {testsRun: 0, failed: 0, duration: 0};
+
+group("Stats");
+
+for (var name in modes) {
+  var stats = modes[name].stats;
+  outputStats(name + " parser", stats);
+  for (var key in stats) total[key] += stats[key];
+}
+
+outputStats("Total", total);
+
+groupEnd();
+
+if (total.failed && typeof process === "object") {
+  process.stdout.write("", function() {
+    process.exit(1);
+  });
+}

--- a/test/tests-jsx.js
+++ b/test/tests-jsx.js
@@ -3607,6 +3607,10 @@ var fbTestFixture = {
               },
               value: {
                 type: "Literal",
+                loc: {
+                  start: { line: 1, column: 8 },
+                  end: { line: 3, column: 15 }
+                },
                 range: [8, 62],
                 value: "M230 80\n\t\tA 45 45, 0, 1, 0, 275 125 \r\n    L 275 80 Z",
                 raw: "\"M230 80\n\t\tA 45 45, 0, 1, 0, 275 125 \r\n    L 275 80 Z\""


### PR DESCRIPTION
This PR ensures multi-line jsx attribute values get the correct `loc.end` info. Previously it didn't handle newlines, so it treated it as if it were just one really long line. This bad data would cause some [really weird behavior](https://github.com/jenseng/react-i18nliner/issues/9) when transforming and reprinting via recast. See the updated test and commit message in c3bf25e for more info.

I also brought back just enough of the old test runner code to make sure i didn't break anything ... now `npm run test` works again :smile: