### PR TITLE
Ensure empty expression tokens ranges are correct

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -244,15 +244,8 @@ module.exports = function(acorn) {
   // at the beginning of the next one (right brace).
 
   pp.jsx_parseEmptyExpression = function() {
-    var tmp = this.start;
-    this.start = this.lastTokEnd;
-    this.lastTokEnd = tmp;
-
-    tmp = this.startLoc;
-    this.startLoc = this.lastTokEndLoc;
-    this.lastTokEndLoc = tmp;
-
-    return this.finishNode(this.startNode(), 'JSXEmptyExpression');
+    var node = this.startNodeAt(this.lastTokEnd, this.lastTokEndLoc);
+    return this.finishNodeAt(node, 'JSXEmptyExpression', this.start, this.startLoc);
   };
 
   // Parses JSX expression enclosed into curly brackets.

--- a/test/tests-jsx.js
+++ b/test/tests-jsx.js
@@ -3634,9 +3634,75 @@ var fbTestFixture = {
 if (typeof exports !== "undefined") {
   var test = require("./driver.js").test;
   var testFail = require("./driver.js").testFail;
+  var tokTypes = require("../").tokTypes;
 }
 
 testFail("var x = <div>one</div><div>two</div>;", "Adjacent JSX elements must be wrapped in an enclosing tag (1:22)");
+
+test('<a>{/* foo */}</a>', {}, {
+  onToken: [
+    {
+      type: tokTypes.jsxTagStart,
+      value: undefined,
+      start: 0,
+      end: 1
+    },
+    {
+      type: tokTypes.jsxName,
+      value: 'a',
+      start: 1,
+      end: 2
+    },
+    {
+      type: tokTypes.jsxTagEnd,
+      value: undefined,
+      start: 2,
+      end: 3
+    },
+    {
+      type: tokTypes.braceL,
+      value: undefined,
+      start: 3,
+      end: 4
+    },
+    {
+      type: tokTypes.braceR,
+      value: undefined,
+      start: 13,
+      end: 14
+    },
+    {
+      type: tokTypes.jsxTagStart,
+      value: undefined,
+      start: 14,
+      end: 15
+    },
+    {
+      type: tokTypes.slash,
+      value: '/',
+      start: 15,
+      end: 16
+    },
+    {
+      type: tokTypes.jsxName,
+      value: 'a',
+      start: 16,
+      end: 17
+    },
+    {
+      type: tokTypes.jsxTagEnd,
+      value: undefined,
+      start: 17,
+      end: 18
+    },
+    {
+      type: tokTypes.eof,
+      value: undefined,
+      start: 18,
+      end: 18
+    }
+  ]
+});
 
 for (var ns in fbTestFixture) {
   ns = fbTestFixture[ns];


### PR DESCRIPTION
Turned out a little bit of trickery in parsing empty expressions was the cause. Still trying to learn how location is calculated, so let me know if this change makes sense.

Fixes #28 