### PR TITLE
Bump Acorn from v2.x to v3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "node test/run.js"
   },
   "dependencies": {
-    "acorn": "^2.0.1"
+    "acorn": "^3.0.4"
   },
   "devDependencies": {
     "chai": "^3.0.0",


### PR DESCRIPTION
npm v3 tries to dedupe the dependencies by default, and keeping dependencies up-to-date helps better deduplication.

v2.x -> v3.x includes a breaking change: https://github.com/ternjs/acorn/blob/master/CHANGELOG.md#300-2016-02-10
