### PR TITLE
Use `license` instead of deprecated `licenses`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,7 @@
     "type": "git",
     "url": "https://github.com/RReverser/acorn-jsx"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://raw.githubusercontent.com/RReverser/acorn-jsx/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "scripts": {
     "test": "node test/run.js"
   },


### PR DESCRIPTION
Because `licenses` is deprecated.

ref.
http://npm1k.org/
https://github.com/npm/npm/releases/tag/v2.10.0
