### PR TITLE
Acorn 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "node test/run.js"
   },
   "dependencies": {
-    "acorn": "^3.0.4"
+    "acorn": "^4.0.4"
   },
   "devDependencies": {
     "chai": "^3.0.0",


### PR DESCRIPTION
I'm trying to get all of Buble's dependencies working on acorn 4.x for packaging reasons. Buble's tests pass with this change, so I'm proposing it in this PR.