### PR TITLE
Support acorn 6 and 7 as peerDependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ env:
   - ACORN_VERSION=6
   - ACORN_VERSION=7
 
-after_install:
+before_script:
   - 'if [ $ACORN_VERSION != 7 ]; then npm install -D acorn@$ACORN_VERSION; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ env:
   - ACORN_VERSION=6
   - ACORN_VERSION=7
 
-before_script:
-  - 'if [ $ACORN_VERSION != 7 ]; then npm install -D acorn@$ACORN_VERSION; fi'
+install:
+  - npm install -D acorn@$ACORN_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: node_js
-sudo: false
 node_js:
   - '4'
-  - '5'
   - '6'
-  - '7'
+  - '8'
+  - '10'
+  - '12'
+env:
+  - ACORN_VERSION=6
+  - ACORN_VERSION=7
+
+after_install:
+  - 'if [ $ACORN_VERSION != 7 ]; then npm install -D acorn@$ACORN_VERSION; fi'

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "test": "node test/run.js"
   },
   "peerDependencies": {
-    "acorn": "^6.0.0"
+    "acorn": "^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
-    "acorn": "^6.0.0"
+    "acorn": "^7.0.0"
   }
 }


### PR DESCRIPTION
Fixes #100 

Runs tests with both v6 and v7, so it doesn't need a major bump in acorn-jsx.